### PR TITLE
Backport: Preserve query string on test client

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,13 @@
 .. currentmodule:: werkzeug
 
+Version 0.15.3.1
+--------------
+
+Released 2022-11-08
+
+-   The test client includes the query string in ``REQUEST_URI`` and
+    ``RAW_URI``. :issue:`1781`
+
 Version 0.15.3
 --------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@ Released 2022-11-08
 
 -   The test client includes the query string in ``REQUEST_URI`` and
     ``RAW_URI``. :issue:`1781`
+-   ``EnvironBuilder.from_environ`` decodes values encoded for WSGI, to
+    avoid double encoding the new values. :pr:`1959`
 
 Version 0.15.3
 --------------

--- a/src/werkzeug/__init__.py
+++ b/src/werkzeug/__init__.py
@@ -17,7 +17,7 @@
 import sys
 from types import ModuleType
 
-__version__ = "0.15.3"
+__version__ = "0.15.3.1"
 
 # This import magic raises concerns quite often which is why the implementation
 # and motivation is explained here in detail now.

--- a/src/werkzeug/test.py
+++ b/src/werkzeug/test.py
@@ -309,7 +309,7 @@ class EnvironBuilder(object):
     :param environ_overrides: an optional dict of environment overrides.
     :param charset: the charset used to encode unicode data.
 
-    .. versionchanged:: 2.0.0
+    .. versionchanged:: 0.15.3.1
         ``REQUEST_URI`` and ``RAW_URI`` is the full raw URI including
         the query string, not only the path.
 

--- a/src/werkzeug/test.py
+++ b/src/werkzeug/test.py
@@ -309,6 +309,10 @@ class EnvironBuilder(object):
     :param environ_overrides: an optional dict of environment overrides.
     :param charset: the charset used to encode unicode data.
 
+    .. versionchanged:: 2.0.0
+        ``REQUEST_URI`` and ``RAW_URI`` is the full raw URI including
+        the query string, not only the path.
+
     .. versionadded:: 0.15
         The ``json`` param and :meth:`json_dumps` method.
 
@@ -361,10 +365,12 @@ class EnvironBuilder(object):
         path_s = make_literal_wrapper(path)
         if query_string is not None and path_s("?") in path:
             raise ValueError("Query string is defined in the path and as an argument")
+        request_uri = url_parse(path)
         if query_string is None and path_s("?") in path:
-            path, query_string = path.split(path_s("?"), 1)
+            query_string = request_uri.query
         self.charset = charset
-        self.path = iri_to_uri(path)
+        self.path = iri_to_uri(request_uri.path)
+        self.request_uri = path
         if base_url is not None:
             base_url = url_fix(iri_to_uri(base_url, charset), charset)
         self.base_url = base_url
@@ -746,9 +752,9 @@ class EnvironBuilder(object):
                 "PATH_INFO": _path_encode(self.path),
                 "QUERY_STRING": qs,
                 # Non-standard, added by mod_wsgi, uWSGI
-                "REQUEST_URI": wsgi_encoding_dance(self.path),
+                "REQUEST_URI": wsgi_encoding_dance(self.request_uri),
                 # Non-standard, added by gunicorn
-                "RAW_URI": wsgi_encoding_dance(self.path),
+                "RAW_URI": wsgi_encoding_dance(self.request_uri),
                 "SERVER_NAME": self.server_name,
                 "SERVER_PORT": str(self.server_port),
                 "HTTP_HOST": self.host,

--- a/tests/test_test.py
+++ b/tests/test_test.py
@@ -825,3 +825,9 @@ def test_raw_request_uri():
     response = client.get("/hello%2fworld")
     data = response.get_data(as_text=True)
     assert data == "/hello/world\n/hello%2fworld"
+
+    response = client.get("/?a=b")
+    assert response.get_data(as_text=True) == "/\n/?a=b"
+
+    response = client.get("/%3f?")  # escaped ? in path, and empty query string
+    assert response.get_data(as_text=True) == "/?\n/%3f?"

--- a/tests/test_test.py
+++ b/tests/test_test.py
@@ -352,17 +352,19 @@ def test_create_environ_query_string_error():
 
 def test_builder_from_environ():
     environ = create_environ(
-        "/foo",
+        "/ㄱ",
         base_url="https://example.com/base",
         query_string={"name": "Werkzeug"},
-        data={"foo": "bar"},
-        headers={"X-Foo": "bar"},
+        data={"foo": "ㄴ"},
+        headers={"X-Foo": "ㄷ"},
     )
     builder = EnvironBuilder.from_environ(environ)
+
     try:
         new_environ = builder.get_environ()
     finally:
         builder.close()
+
     assert new_environ == environ
 
 


### PR DESCRIPTION
Backport the fixes from upstream and tag new version `0.15.3.1`

https://github.com/pallets/werkzeug/pull/1853
https://github.com/pallets/werkzeug/pull/1960